### PR TITLE
Use bare git mirror

### DIFF
--- a/lib/Test/Smoke/Syncer/Git.pm
+++ b/lib/Test/Smoke/Syncer/Git.pm
@@ -46,7 +46,7 @@ For the mirror-repository we do:
 
 For the working-repository we do:
 
-    git clone $gitdir $ddir # if not set up
+    git clone --local $gitdir $ddir # if not set up
     git reset --hard HEAD
     git clean -dfx
     git fetch --all
@@ -101,7 +101,7 @@ sub sync {
     if ( ! -d $self->{ddir} || ! -d catdir($self->{ddir}, '.git') ) {
         # It needs to be empty ...
         my $cloneout = $gitbin->run(
-            clone => $self->{gitdir},
+            clone => '--local' => $self->{gitdir},
             $self->{ddir},
             '2>&1'
         );

--- a/t/syncer_git.t
+++ b/t/syncer_git.t
@@ -79,7 +79,8 @@ print <>;
         );
 
         $syncer->sync();
-        ok(!-e catfile(catdir($playground, 'git-perl'), '.patch'), "  no .patch for gitdir");
+        ok( !$git->run( '-C', catdir($playground, 'git-perl'), 'ls-tree', '--name-only', 'master', '.patch' ),
+            "  no .patch for gitdir");
         ok(-e catfile(catdir($playground, 'perl-current'), '.patch'), "  .patch created");
 
         # Update upstream/master
@@ -90,7 +91,8 @@ print <>;
         chdir catdir(updir, updir);
 
         $syncer->sync();
-        ok(-e catfile(catdir($playground, 'git-perl'), 'new_file'), "new_file exits after sync()");
+        is( $git->run( '-C', catdir($playground, 'git-perl'), 'ls-tree', '--name-only', 'master', 'new_file' ),
+            "new_file\n", "new_file exits after sync()");
         ok(-e catfile(catdir($playground, 'perl-current'), 'new_file'), "new_file exits after sync()");
 
         # Create upstream/smoke-me


### PR DESCRIPTION
I had issues with index locks in my proxy checkout, this switches the proxy to use a "bare" checkout that avoids the issue. There's no reason to have a full checkout there. It also allows us to use a --local checkout for the work tree which saves space and can be a bit faster due to not having to copy so many files around.