### PR TITLE
WIP: Print output as it's happening

### DIFF
--- a/lib/Test/Smoke/Smoker.pm
+++ b/lib/Test/Smoke/Smoker.pm
@@ -7,7 +7,7 @@ our $VERSION = '0.046';
 use Config;
 use Cwd;
 use File::Spec::Functions qw( :DEFAULT abs2rel rel2abs );
-use Capture::Tiny 'capture';
+use Capture::Tiny 'capture', 'tee';
 use Test::Smoke::LogMixin;
 use Test::Smoke::Util qw( get_smoked_Config skip_filter );
 
@@ -761,6 +761,8 @@ sub _run_harness3_target {
     my $file;
     my $found = 0;
     while ( $line = <$tst> ) {
+        print STDOUT $line;
+
         #$self->log_debug($line);
 
         # This line with timings only has to be logged to .out.
@@ -834,6 +836,9 @@ sub _run_harness3_target {
     }
 
     my @dump = <$tst>; # Read trailing output from pipe
+    for my $line (@dump) {
+        print STDOUT $line;
+    }
 
     close $tst or do {
         my $error = $! || ( $? >> 8);
@@ -1196,8 +1201,7 @@ sub _run {
     $self->log_debug("[$command]");
     defined $sub and return &$sub( $command, @args );
 
-    my ( $out, $err, $res ) = capture { system $command };
-    $self->log($err) if $err;
+    my ( $out, $err, $res ) = tee { system $command };
     $self->{_run_exit} = $res >> 8;
     return wantarray ? split /(\r\n|\r|\n)/, $out : $out;
 }


### PR DESCRIPTION
With the current code it first runs the command (make, test_harness, ...) and when it's complete it *may* 'log' all the output on STDOUT/smokecurrent.log.

What *I* like more is if the output shows when things are happening instead of needing to wait until the command fully completed.

With this patch that does happen for
- `make`
- `make test_harness`

I consider this to be WIP because:
	a) Should this behavior be configurable?
	b) For `_run_harness3_target` (and others) it uses a pipe and then
	   reads from it. I'm *guessing* that it should be possible to replace
	   the code with `capture` (or `tee`) from Capture::Tiny but I don't
	   know if that is desirable.
	c) On Windows some output is now duplicated in the log because stdout
	   of `make` is already logged (see `$make_output` in `sub make_`).
	d) This is incomplete: only '_run_harness3_target' was updated but
	   other code has the same structure.
	e) It causes the messages (from make, test_harness3) to be logged
	   without timestamp. Before if the output of make was logged (for
	   example on Windows) all messages were logged with the same timestamp.
	   (Ideally each message would have a timestamp of when it happened but
	    that might not be feasible with Capture::Tiny)