### PR TITLE
fix: HandleQueue gracefully handles missing qfile configuration

### DIFF
--- a/lib/Test/Smoke/App/HandleQueue.pm
+++ b/lib/Test/Smoke/App/HandleQueue.pm
@@ -71,20 +71,22 @@ sub new {
     my $class = shift;
     my $self = $class->SUPER::new(@_);
 
-    $self->{_poster} = Test::Smoke::Poster->new(
-        $self->option('poster') => $self->options,
+    if (defined($self->option('qfile'))) {
+        $self->{_poster} = Test::Smoke::Poster->new(
+            $self->option('poster') => $self->options,
 
-        # We will need to fake 'ddir' in order to get the reports from the
-        # archive
-        ddir => $self->option('adir'),
-        v    => $self->option('verbose'),
-    );
-    $self->{_queue} = Test::Smoke::PostQueue->new(
-        adir   => $self->option('adir'),
-        qfile  => $self->option('qfile'),
-        v      => $self->option('verbose'),
-        poster => $self->poster,
-    );
+            # We will need to fake 'ddir' in order to get the reports from the
+            # archive
+            ddir => $self->option('adir'),
+            v    => $self->option('verbose'),
+        );
+        $self->{_queue} = Test::Smoke::PostQueue->new(
+            adir   => $self->option('adir'),
+            qfile  => $self->option('qfile'),
+            v      => $self->option('verbose'),
+            poster => $self->poster,
+        );
+    }
 
     return $self;
 }
@@ -98,6 +100,7 @@ Try to send all items in the queue and remove items that are no longer in the ar
 sub run {
     my $self = shift;
 
+    return unless defined($self->{_queue});
     $self->queue->handle();
     $self->queue->purge();
 }

--- a/t/app/170-handlequeue.t
+++ b/t/app/170-handlequeue.t
@@ -13,6 +13,7 @@ use File::Path qw< mkpath >;
 
 use Test::Smoke::App::Options;
 use Test::Smoke::App::HandleQueue;
+use Test::Smoke::PostQueue;
 
 my $commit = '9d4a846c758608a6297babf9582967e036edfa1f';
 my $non_commit = '9d4a846c758608a6297babf9582967e036edfa20';
@@ -24,6 +25,27 @@ my $qfile = catfile($tempdir, "${prefix}.qfile");
 prepare_archive($adir, $commit);
 prepare_queue($qfile, $commit, $non_commit);
 
+# Test that HandleQueue works gracefully when qfile is not configured.
+# This must run first, before any PostQueue singleton is created.
+{
+    local @ARGV = (
+        '--adir',  $adir,
+        '--smokedb_url', 'http://localhost/report',
+        '--poster' => 'HTTP::Tiny',
+        # no --qfile
+    );
+    my $app;
+    eval {
+        $app = Test::Smoke::App::HandleQueue->new(
+            Test::Smoke::App::Options->handlequeue_config
+        );
+    };
+    is($@, '', "HandleQueue->new() does not die when qfile is not configured");
+    isa_ok($app, 'Test::Smoke::App::HandleQueue');
+
+    my $result = eval { $app->run(); 1 };
+    is($@, '', "HandleQueue->run() does not die when qfile is not configured");
+}
 
 {
     no warnings 'redefine';


### PR DESCRIPTION
Fix #11

When the smoker is started without qfile configured, HandleQueue->new()
would unconditionally pass qfile=>undef to PostQueue->new(), which
validates the attribute and dies with a confusing internal error.

Guard PostQueue creation behind a defined-check on qfile so that
HandleQueue is a no-op when the queue feature is not configured.
