### PR TITLE
Change author email address

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -12,7 +12,7 @@ Dan Collins <dcollinsn@gmail.com>
 David Cantrell
 Dominic Dunlop
 H.Merijn Brand - Tux <linux@tux.freedom.nl>
-James E Keenan <jkeenan@cpan.org>
+James E Keenan <jamesekeenan@yahoo.com>
 Jarkko Hietaniemi
 Nicholas Clark
 Nigel Horne <njh@bandsman.co.uk>


### PR DESCRIPTION
As consequence of demise of cpan.org mail forwarding.