### PR TITLE
Test::Smoke::read_config(): Improve coverage by test suite

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -157,6 +157,7 @@ my %TEST_REQUIRES = (
     'HTTP::Message'    => 0,
     'JSON'             => 4.10,
     'Path::Tiny'       => 0, # To be revised (?). Only used by tsarchivelog.pl
+    'File::Temp'       => 0,
     ($mmver > 6.64 ? (%BUILD_REQUIRES) : ()),
 );
 

--- a/lib/Test/Smoke.pm
+++ b/lib/Test/Smoke.pm
@@ -42,6 +42,14 @@ C<Test::Smoke> exports C<$conf> and C<read_config()> by default.
 
 Read (require) the configfile.
 
+Takes one optional argument: a string holding the name of the configuration
+file.  Defaults to C<smokecurrent_config>.
+
+If there is an error in reading the configuration file, C<read_config()>
+returns an undefined value; the content of the error can be found by calling
+C<config_error()>.  If there is no such error, C<read_config()> returns a true
+value.
+
 =cut
 
 sub read_config {
@@ -63,7 +71,7 @@ sub read_config {
 
 =head2 Test::Smoke->config_error()
 
-Return the value of C<$ConfigError>
+Return the value of C<$ConfigError>.
 
 =cut
 

--- a/t/ts_config.t
+++ b/t/ts_config.t
@@ -1,42 +1,79 @@
 #! /usr/perl/perl -w
 use strict;
 
-# $Id$
-
-use FindBin;
 use Data::Dumper;
-use vars qw( $conf );
+use File::Temp qw/ tempdir /;
+our $conf;
 
-use Test::More tests => 9 - 1;
+use Test::More;
 BEGIN { use_ok( 'Test::Smoke' ) }
 
-#is( Test::Smoke->VERSION, $Test::Smoke::VERSION, 
-#    "Check version $Test::Smoke::VERSION" );
+note("\$Test::Smoke::VERSION: $Test::Smoke::VERSION");
 
 ok( defined &read_config, "read_config() is exported" );
 
 my $test = { ddir => '../' };
+my $tdir = tempdir(CLEANUP => 1);
+my $prefix = 'smokecurrent';
 
-SKIP: {
-    my $prefix = 'smokecurrent';
-    my $config_name = File::Spec->catfile( $FindBin::Bin, 
-                                           "${prefix}_config" );
-    local *FILE;
-    open FILE, "> $config_name" or skip "Cannot write file: $!", 2;
-    print FILE Data::Dumper->Dump( [$test], ['conf'] );
-    close FILE or skip "Cannot close file: $!", 2;
+{
+    note("Simplest case: actual file named 'smokecurrent_config'");
 
-    ok( read_config( $config_name ), "read_config($config_name)" );
+    my $config_basename =  "${prefix}_config";
+    my $config_path = File::Spec->catfile($tdir, $config_basename);
+
+    open my $FH1, '>', $config_path or die "Cannot write file: $!";
+    print $FH1 Data::Dumper->Dump( [$test], ['conf'] );
+    close $FH1 or die "Cannot close file: $!";
+
+    ok( read_config( $config_path ), "read_config($config_path)" );
     is( Test::Smoke->config_error, undef, "No errors" );
     is_deeply( $conf, $test, "Configuration compares" );
-
-    undef $conf;
-    my $config_short = File::Spec->catfile( $FindBin::Bin, $prefix );
-    ok( read_config( $config_short ), "read_config($config_short)" );
-    is( Test::Smoke->config_error, undef, "No errors" );
-    is_deeply( $conf, $test, "Configuration compares after reloading" );
-
-    1 while unlink $config_name;
 }
 
-    
+{
+    note("No explicit argument to read_config() and no actual config file");
+
+    my $rv = read_config();
+    ok(! defined $rv, "read_config returned undefined value");
+    my $error = Test::Smoke::config_error();
+    ok(length($error), "non-zero length string returned for config error");
+    like($error, qr/^Can't locate smokecurrent_config/s,
+        "Got expected configuration error message");
+}
+
+{
+    note("Argument to read_config is empty string; no actual config file");
+
+    my $rv = read_config('');
+    ok(! defined $rv, "read_config returned undefined value");
+    my $error = Test::Smoke::config_error();
+    ok(length($error), "non-zero length string returned for config error");
+    like($error, qr/^Can't locate smokecurrent_config/s,
+        "Got expected configuration error message");
+}
+
+{
+    note("Explicit argument to read_config,\n\tactual file whose name does not end in '_config'");
+
+    my $config_basename =  "ultra";
+    my $config_path = File::Spec->catfile($tdir, $config_basename);
+
+    open my $FH2, '>', $config_path or die "Cannot write file: $!";
+    print $FH2 Data::Dumper->Dump( [$test], ['conf'] );
+    close $FH2 or die "Cannot close file: $!";
+
+    ok( read_config( $config_path ), "read_config($config_path)" );
+    is( Test::Smoke->config_error, undef, "No errors" );
+    is_deeply( $conf, $test, "Configuration compares" );
+}
+
+undef $conf;
+
+my $config_short = File::Spec->catfile( $tdir, $prefix );
+ok( read_config( $config_short ), "read_config($config_short)" );
+is( Test::Smoke->config_error, undef, "No errors" );
+is_deeply( $conf, $test, "Configuration compares after reloading" );
+
+done_testing();
+


### PR DESCRIPTION
Coverage analysis via Devel::Cover indicated unexercised branches and conditions in read_config() and config_error().  This patch maxes out statement, branch and coverage for those subroutines.

To achieve this, t/ts_config.t was updated in certain aspects:  use of tempfiles to simulate TS configuration files; tests arranged in stanzas; use of more up-to-date features of Test::More.

To use 'skip' if we cannot open or close a tempfile for writing deprives us of important knowledge about our system and may cause to ignore real problems.  Instead, die if we cannot test in a modern way.

Replace 'use vars' with more modern 'our'.

Better documentation for Test::Smoke::read_config()