### PR TITLE
TS::App::SendReport: provide lookup URL

### DIFF
--- a/lib/Test/Smoke/App/SendReport.pm
+++ b/lib/Test/Smoke/App/SendReport.pm
@@ -55,7 +55,11 @@ sub run {
         );
         $self->log_info("==> Starting poster");
         my $id = $self->poster->post();
-        $self->log_warn("%s/%s", $self->option('smokedb_url'), $id);
+        my $smokedb_url = $self->option('smokedb_url');
+        my ($domain, $report_string) = $smokedb_url =~ m{^(.*?)\/api\/(.*)$};
+        my $visible_url = sprintf("%s/%s" => $domain, $report_string);
+        $self->log_warn("%s/%s", "Post URL:   $smokedb_url", $id);
+        $self->log_warn("%s/%s", "Visible at: $visible_url", $id);
         return $id;
     }
     else {


### PR DESCRIPTION
In the `smokecurrent.log` generated by older versions of Test-Smoke, once the report had successfully been sent to the CoreSmokeDB, a URL was printed which the user could plug into a browser's address bar and be taken immediately to the web version of the report.

At some point the functioning of the web application was changed such that the URL which the program used to send the report to the database became different from that anyone using a browser would use to locate the report on the web.

This patch modifies one line of output from
Test::Smoke::App::SendReport::run() and adds one new line to distinguish between the "POST URL" used internally by Test-Smoke and the "GET URL" used by users of the web view of CoreSmokeDB.

Fixes: https://github.com/Perl-Toolchain-Gang/Test-Smoke/issues/41