### PR TITLE
TS::Patcher: improve handling/testing of new()

### DIFF
--- a/lib/Test/Smoke/Patcher.pm
+++ b/lib/Test/Smoke/Patcher.pm
@@ -152,12 +152,19 @@ sub new {
     my $proto = shift;
     my  $class = ref $proto || $proto;
 
-    my $type = lc shift;
-print STDERR "AAA: <$type>\n";
-    unless ( $type && exists $CONFIG{valid_type}->{ $type } ) {
-        defined $type or $type = 'undef';
+    my $type;
+    my $check_arg = 0;
+    if (! defined $_[0] or !$_[0]) {
+        $type = 'undef';
         require Carp;
-        Carp::croak( "Invalid Patcher-type: '$type'" );
+        Carp::croak( "Patcher type not provided" );
+    }
+    else {
+        $type = lc shift;
+        unless ( exists $CONFIG{valid_type}->{ $type } ) {
+            require Carp;
+            Carp::croak( "Invalid Patcher-type: '$type'" );
+        }
     }
 
     my %args_raw = @_ ? UNIVERSAL::isa( $_[0], 'HASH' ) ? %{ $_[0] } : @_ : ();

--- a/lib/Test/Smoke/Patcher.pm
+++ b/lib/Test/Smoke/Patcher.pm
@@ -135,7 +135,7 @@ Constant: 2**MAX_FLAG_COUNT) - 1
 
 =item Test::Smoke::Patcher->new( $type => \%args );
 
-C<new()> crates the object. Valid types are B<single> and B<multi>.
+C<new()> creates the object. Valid types are B<single> and B<multi>.
 Valid keys for C<%args>:
 
     * ddir:     the build directory

--- a/lib/Test/Smoke/Patcher.pm
+++ b/lib/Test/Smoke/Patcher.pm
@@ -72,7 +72,7 @@ There are four (4) ways to specify that patch.
 
 =over 4
 
-=item I<refernece to a SCALAR>
+=item I<reference to a SCALAR>
 
 The scalar holds the complete patch as literal text.
 
@@ -153,6 +153,7 @@ sub new {
     my  $class = ref $proto || $proto;
 
     my $type = lc shift;
+print STDERR "AAA: <$type>\n";
     unless ( $type && exists $CONFIG{valid_type}->{ $type } ) {
         defined $type or $type = 'undef';
         require Carp;

--- a/t/patcher.t
+++ b/t/patcher.t
@@ -189,7 +189,7 @@ SKIP: { # Test multi mode
     select( (select(PINFO), $|++)[0] );
     print PINFO <<EOPINFO;
 $relpatch
-# Do some somments 
+# Do some comments
 # This is to take out #20001, so we can see what happend
 $relpatch;-R
 $relpatch
@@ -198,7 +198,7 @@ EOPINFO
     eval { $patcher->patch_multi( \*PINFO ) };
     ok( ! $@, "No Errors while running patch $@" );
     $newfile = get_file($tmpdir, qw( perl patchme.txt ));
-    like( $newfile, '/^VERSION == 20001$/m', "Conent OK" );
+    like( $newfile, '/^VERSION == 20001$/m', "Content OK" );
     close PINFO;
     1 while unlink $pinfo;
 
@@ -209,14 +209,14 @@ EOPINFO
     eval { $patcher->patch_multi( File::Spec->rel2abs($pinfo) ) };
     ok( ! $@, "No Errors while running patch $@" );
     $newfile = get_file($tmpdir, qw( perl patchme.txt ));
-    unlike( $newfile, '/^VERSION == 20001$/m', "Conent OK" );
+    unlike( $newfile, '/^VERSION == 20001$/m', "Content OK" );
     1 while unlink $pinfo;
 
     my $descr = '[PATCH] just testing comments';
     eval { $patcher->patch_single( $relpatch, '', $descr ) };
     ok ! $@, "Patch applied($descr) $@";
     $newfile = get_file($tmpdir, qw( perl patchme.txt ));
-    like( $newfile, '/^VERSION == 20001$/m', "Conent OK" );
+    like( $newfile, '/^VERSION == 20001$/m', "Content OK" );
     my $plevel = get_file($tmpdir, qw( perl patchlevel.h ));
     like $plevel, qq{/^\\s*,"\Q$descr\E"/m},
          "Description added to patchlevel.h";

--- a/t/patcher.t
+++ b/t/patcher.t
@@ -12,7 +12,7 @@ use TestLib;
 use Cwd 'abs_path';
 use File::Temp 'tempdir';
 
-use Test::More tests => 41;
+use Test::More tests => 44;
 BEGIN { use_ok( 'Test::Smoke::Patcher' ) };
 my $verbose = exists $ENV{SMOKE_VERBOSE} ? $ENV{SMOKE_VERBOSE} : 0;
 
@@ -40,6 +40,51 @@ $verbose and diag( "Found patch: '$patch'" );
 my $testpatch = File::Spec->catfile( 't', 'test.patch' );
 my $curdir = abs_path('.');
 my $tmpdir = tempdir(CLEANUP => 1);
+
+{
+    # Error handling: patcher type invalid or missing
+
+    my $type;
+
+    $type = 'double';
+    eval {
+        my $patcher = Test::Smoke::Patcher->new(
+            $type => {
+                v         => $verbose,
+                -ddir     => File::Spec->catdir($tmpdir, 'perl'),
+                -patchbin => $patch,
+            }
+        );
+    };
+    like($@, qr/Invalid Patcher-type: '$type'/,
+        "Patcher->new() failed due to invalid type '$type'");
+
+    $type = undef;
+    eval {
+        my $patcher = Test::Smoke::Patcher->new(
+            $type => {
+                v         => $verbose,
+                -ddir     => File::Spec->catdir($tmpdir, 'perl'),
+                -patchbin => $patch,
+            }
+        );
+    };
+    like($@, qr/Patcher type not provided/,
+        "Patcher->new(): invalid second argument");
+
+    $type = '';
+    eval {
+        my $patcher = Test::Smoke::Patcher->new(
+            $type => {
+                v         => $verbose,
+                -ddir     => File::Spec->catdir($tmpdir, 'perl'),
+                -patchbin => $patch,
+            }
+        );
+    };
+    like($@, qr/Patcher type not provided/,
+        "Patcher->new(): invalid second argument");
+}
 
 SKIP: { # test Test::Smoke::Patcher->patch_single()
     my $to_skip = 13;


### PR DESCRIPTION
2 commits here, which in principle could be applied separately.

First: correction of one typo in documentation.

Second: slight refactoring of `Test::Smoke::Patcher->new()`s argument validation, for the purpose of improving test coverage.  Before this patch, statement/branch/condition coverage was:
```
	84.8	65.5	46.8
```
after:
```
	86.9	68.8	53.1
```