### PR TITLE
Test::Smoke::Patcher: Extend coverage of args_raw assignment in new()

### DIFF
--- a/t/patcher.t
+++ b/t/patcher.t
@@ -12,7 +12,7 @@ use TestLib;
 use Cwd 'abs_path';
 use File::Temp 'tempdir';
 
-use Test::More tests => 47;
+use Test::More tests => 49;
 BEGIN { use_ok( 'Test::Smoke::Patcher' ) };
 my $verbose = exists $ENV{SMOKE_VERBOSE} ? $ENV{SMOKE_VERBOSE} : 0;
 
@@ -307,6 +307,38 @@ EOF
     isa_ok( $patcher, 'Test::Smoke::Patcher' );
     is($patcher->{v}, $expected_value,
         "Got expected value when argument is set via config()");
+}
+
+SKIP: {
+    my $to_skip = 1;
+    skip "Cannot find a working 'patch' program.", $to_skip unless $patch;
+
+    # In Test::Smoke::Patcher, the assignment to %args_raw suggests that the
+    # following (invocant followed by string indicating type) is a legitimate
+    # way to construct a TS::Patcher object.  Should it be?  We add this test
+    # to extend branch coverage.
+
+    my $patcher = Test::Smoke::Patcher->new('single');
+    isa_ok( $patcher, 'Test::Smoke::Patcher' );
+}
+
+SKIP: {
+    my $to_skip = 1;
+    skip "Cannot find a working 'patch' program.", $to_skip unless $patch;
+
+    # In Test::Smoke::Patcher, the assignment to %args_raw suggests that the
+    # following (invocant followed by string indicating type followed by list
+    # of key-value pairs) is a legitimate way to construct a TS::Patcher
+    # object.  Should it be?  We add this test to extend branch coverage.
+
+    my $patcher = Test::Smoke::Patcher->new(
+        'single', (
+            v         => $verbose,
+            -ddir     => File::Spec->catdir($tmpdir, 'perl'),
+            -patchbin => $patch,
+        ),
+    );
+    isa_ok( $patcher, 'Test::Smoke::Patcher' );
 }
 
 END {


### PR DESCRIPTION
In Patcher::new(), the assignment to args_raw is a nested ternary condition.  Only 2 of the 4 possible outcomes were being exercised by the test suite.  This patch exercises the remaining two.