### PR TITLE
More precise exclusions in MANIFEST.SKIP

### DIFF
--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -24,6 +24,5 @@ sandbox/
 \.github
 Makefile.PL.bak
 Test-Smoke-
-smokecurrent
 ^local/
-
+data/configs/smokecurrent*


### PR DESCRIPTION
The pattern 'smokecurrent' heretofore found in MANIFEST.SKIP caused the removal from the MANIFEST of files that we probably want to have present both in a git checkout and a tarball.  One such file was: t/logs/rtc-126010/smokecurrent.log.  This patch should be applied if the files matching data/configs/smokecurrent* are needed *only* in the repository -- and not on CPAN.

This is a *suggested* fix for GH #52.