### PR TITLE
TS::Mailer::Base: Add test file to exercise code directly

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -162,6 +162,7 @@ t/logs/solaris.log
 t/logs/w32bcc32.log
 t/lpatches.t
 t/mailer.t
+t/mailer-base.t
 t/multilocale.out
 t/parse_report.t
 t/patcher.t

--- a/t/mailer-base.t
+++ b/t/mailer-base.t
@@ -1,0 +1,71 @@
+use strict;
+use warnings;
+
+use Cwd;
+use File::Copy;
+use File::Spec;
+use File::Temp qw/ tempdir /;
+
+use Test::More;
+
+use_ok( 'Test::Smoke::Mailer::Base' );
+
+my $cwd = cwd();
+my $dummy_copy_dir = File::Spec->catdir($cwd, 't', 'logs', 'rtc-126010');
+ok(-d $dummy_copy_dir, "Located directory for dummy copy");
+my $rpt = 'mktest.rpt';
+my $rpt_file = File::Spec->catfile($dummy_copy_dir, $rpt);
+ok(-f $rpt_file, "rpt file located for testing");
+
+my $tdir = tempdir(CLEANUP => 1);
+
+copy $rpt_file => $tdir or die;
+
+{
+    my %mailer_args = (
+        bcc             => '',
+        cc              => '',
+        ccp5p_onfail    => 0,
+        ddir            => $tdir,
+        from            => '',
+        rptfile         => $rpt,
+        to              => 'daily-build-reports@perl.org',
+        sendmailbin     => 'sendmail',
+        v               => 0,
+    );
+    my $mailer = Test::Smoke::Mailer::Base->new(%mailer_args);
+    isa_ok($mailer, 'Test::Smoke::Mailer::Base');
+
+    my $string = $mailer->fetch_report();
+    like($string, qr/^Smoke/, "Got expected response from fetch_report");
+}
+
+{
+    my $bad_report = "$$-nonexistent-report.txt";
+    my %mailer_args = (
+        bcc             => '',
+        cc              => '',
+        ccp5p_onfail    => 0,
+        ddir            => $tdir,
+        from            => '',
+        rptfile         => $bad_report,
+        to              => 'daily-build-reports@perl.org',
+        sendmailbin     => 'sendmail',
+        v               => 0,
+    );
+    my $mailer = Test::Smoke::Mailer::Base->new(%mailer_args);
+    isa_ok($mailer, 'Test::Smoke::Mailer::Base');
+
+    local $@;
+    my $bad_report_path = File::Spec->catfile($tdir, $bad_report);
+    ok(! -f $bad_report_path, "File does not exist (as intended)");
+    my $expect = "Cannot read '\Q$bad_report_path\E'";
+    eval { $mailer->fetch_report(); };
+    like($@, qr/^$expect/,
+        "Got expected error message from non-existent report file");
+
+    my $error = $mailer->error();
+    is($error, '', "No error because none set directly in Test::Smoke::Mailer::Base");
+}
+
+done_testing();


### PR DESCRIPTION
When testing Test-Smoke on machines where some or all of the various mailer mechanisms are lacking, much of the code in `lib/Test/Smoke/Mailer/Base.pm` is unexercised ("uncovered").  This p.r. adds a new file, `t/mailer-base.t`, to address that problem.

**Note:** In the course of working on this p.r., one flaw in `MANIFEST.SKIP` was discovered; see https://github.com/Perl-Toolchain-Gang/Test-Smoke/issues/52 and review https://github.com/Perl-Toolchain-Gang/Test-Smoke/pull/53.

**Note:** In the course of working on this p.r. a flaw was spotted in `Test::Smoke::Mailer::Base::_get_cc()`.  To properly demonstrate this flaw we should already have `t/mailer-base.t` already in the codebase, so I'm not making any changes to that function in this pull request.