### PR TITLE
Test::Smoke::Mailer::Base::_get_cc(): extend test coverage

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -162,6 +162,7 @@ t/logs/solaris.log
 t/logs/w32bcc32.log
 t/lpatches.t
 t/mailer.t
+t/mailer-base.t
 t/multilocale.out
 t/parse_report.t
 t/patcher.t

--- a/lib/Test/Smoke/Mailer/Base.pm
+++ b/lib/Test/Smoke/Mailer/Base.pm
@@ -81,16 +81,48 @@ by the new global regex kept in C<< $Test::Smoke::Mailer::NOCC_RE >>.
 
 sub _get_cc {
     my( $self, $subject ) = @_;
-    return "" if $subject =~ m/$Test::Smoke::Mailer::NOCC_RE/;
+
+    return "" if $subject =~ m/$Test::Smoke::Mailer::Base::NOCC_RE/;
 
     return $self->{cc} || "" unless $self->{ccp5p_onfail};
 
-    my $p5p = $Test::Smoke::Mailer::P5P or return $self->{cc};
+    my $p5p = $Test::Smoke::Mailer::Base::P5P or return $self->{cc};
     my @cc = $self->{cc} ? $self->{cc} : ();
 
     push @cc, $p5p unless $self->{to} =~ /\Q$p5p\E/ ||
                           $self->{cc} =~ /\Q$p5p\E/;
     return join ", ", @cc;
+
+#    if ($subject =~ m/$Test::Smoke::Mailer::Base::NOCC_RE/) {
+#        return '';
+#    }
+#    else {
+#
+#        if (! $self->{ccp5p_onfail}) {
+#            return $self->{cc} || "";
+#        }
+#        else {
+#            if (! $Test::Smoke::Mailer::Base::P5P) {
+#                return $self->{cc};
+#            }
+#            else {
+#                # subject is neither PASS nor Fail
+#                # ccp5p_onfail is true
+#                # $Test::Smoke::Mailer::Base is populated
+#                # cc is true or not
+#                my $p5p = $Test::Smoke::Mailer::Base::P5P;
+#                my @cc = $self->{cc} ? $self->{cc} : ();
+#
+#                # Push onto @cc the P5P list address unless that list is already the
+#                # value assigned to the 'to' element or the 'cc' element.
+#
+#                if (! ($self->{to} =~ /\Q$p5p\E/ || $self->{cc} =~ /\Q$p5p\E/) ) {
+#                    push @cc, $p5p;
+#                }
+#                return join ", ", @cc;
+#            }
+#        }
+#    }
 }
 
 

--- a/t/mailer-base.t
+++ b/t/mailer-base.t
@@ -21,18 +21,22 @@ my $tdir = tempdir(CLEANUP => 1);
 
 copy $rpt_file => $tdir or die;
 
+my %basic_mailer_args = (
+    bcc             => '',
+    cc              => '',
+    ccp5p_onfail    => 0,
+    ddir            => $tdir,
+    from            => '',
+    rptfile         => $rpt,
+    to              => 'daily-build-reports@perl.org',
+    sendmailbin     => 'sendmail',
+    v               => 0,
+);
+
 {
-    my %mailer_args = (
-        bcc             => '',
-        cc              => '',
-        ccp5p_onfail    => 0,
-        ddir            => $tdir,
-        from            => '',
-        rptfile         => $rpt,
-        to              => 'daily-build-reports@perl.org',
-        sendmailbin     => 'sendmail',
-        v               => 0,
-    );
+    note("minimal arguments for new() and fetch_report()");
+
+    my %mailer_args = map { $_ => $basic_mailer_args{$_}  } keys %basic_mailer_args;
     my $mailer = Test::Smoke::Mailer::Base->new(%mailer_args);
     isa_ok($mailer, 'Test::Smoke::Mailer::Base');
 
@@ -41,18 +45,98 @@ copy $rpt_file => $tdir or die;
 }
 
 {
+    note("exercise _get_cc(): 1");
+
+    my %mailer_args = map { $_ => $basic_mailer_args{$_}  } keys %basic_mailer_args;
+    my $mailer = Test::Smoke::Mailer::Base->new(%mailer_args);
+    isa_ok($mailer, 'Test::Smoke::Mailer::Base');
+
+    my ($subject, $rv);
+    $subject = ' PASS';
+    $rv = $mailer->_get_cc($subject);
+    is($rv, '', "_get_cc() returned empty string, as expected");
+
+    $subject = ' FAIL(X)';
+    $rv = $mailer->_get_cc($subject);
+    is($rv, '', "_get_cc() returned empty string, as expected");
+
+    $subject = ' UNKNOWN';
+    $rv = $mailer->_get_cc($subject);
+    is($rv, '', "_get_cc() returned empty string, as expected");
+}
+
+{
+    note("exercise _get_cc(): 2");
+
+    my %mailer_args = map { $_ => $basic_mailer_args{$_}  } keys %basic_mailer_args;
+    $mailer_args{ccp5p_onfail} = 1;
+    local $Test::Smoke::Mailer::Base::P5P = '';
+    my $mailer = Test::Smoke::Mailer::Base->new(%mailer_args);
+    isa_ok($mailer, 'Test::Smoke::Mailer::Base');
+
+    my ($subject, $rv);
+    $subject = ' UNKNOWN';
+    $rv = $mailer->_get_cc($subject);
+    is($rv, '', "_get_cc() returned empty string, as expected");
+}
+
+{
+    note("exercise _get_cc(): 3");
+
+    my %mailer_args = map { $_ => $basic_mailer_args{$_}  } keys %basic_mailer_args;
+    $mailer_args{ccp5p_onfail} = 1;
+    my $this_cc = 'foo@bar.com';
+    $mailer_args{cc} = $this_cc;
+    local $Test::Smoke::Mailer::Base::P5P = '';
+    my $mailer = Test::Smoke::Mailer::Base->new(%mailer_args);
+    isa_ok($mailer, 'Test::Smoke::Mailer::Base');
+
+    my ($subject, $rv);
+    $subject = ' UNKNOWN';
+    $rv = $mailer->_get_cc($subject);
+    is($rv, $this_cc, "_get_cc() returned expected email address");
+}
+
+{
+    note("exercise _get_cc(): 4");
+
+    my %mailer_args = map { $_ => $basic_mailer_args{$_}  } keys %basic_mailer_args;
+    $mailer_args{ccp5p_onfail} = 1;
+    my $this_cc = 'foo@bar.com';
+    $mailer_args{cc} = $this_cc;
+    local $Test::Smoke::Mailer::Base::P5P = '';
+    my $mailer = Test::Smoke::Mailer::Base->new(%mailer_args);
+    isa_ok($mailer, 'Test::Smoke::Mailer::Base');
+
+    my ($subject, $rv);
+    $subject = ' UNKNOWN';
+    $rv = $mailer->_get_cc($subject);
+    is($rv, $this_cc, "_get_cc() returned expected email addresses");
+}
+
+{
+    note("exercise _get_cc(): 5");
+
+    my %mailer_args = map { $_ => $basic_mailer_args{$_}  } keys %basic_mailer_args;
+    $mailer_args{ccp5p_onfail} = 1;
+    my $this_cc = '';
+    $mailer_args{cc} = $this_cc;
+    my $mailer = Test::Smoke::Mailer::Base->new(%mailer_args);
+    isa_ok($mailer, 'Test::Smoke::Mailer::Base');
+
+    my ($subject, $rv);
+    $subject = ' UNKNOWN';
+    $rv = $mailer->_get_cc($subject);
+    is($rv, $Test::Smoke::Mailer::Base::P5P,
+        "_get_cc() returned P5P list address, as expected");
+}
+
+{
+    note("report file missing");
+
     my $bad_report = "$$-nonexistent-report.txt";
-    my %mailer_args = (
-        bcc             => '',
-        cc              => '',
-        ccp5p_onfail    => 0,
-        ddir            => $tdir,
-        from            => '',
-        rptfile         => $bad_report,
-        to              => 'daily-build-reports@perl.org',
-        sendmailbin     => 'sendmail',
-        v               => 0,
-    );
+    my %mailer_args = map { $_ => $basic_mailer_args{$_}  } keys %basic_mailer_args;
+    $mailer_args{rptfile} = $bad_report;
     my $mailer = Test::Smoke::Mailer::Base->new(%mailer_args);
     isa_ok($mailer, 'Test::Smoke::Mailer::Base');
 

--- a/t/mailer-base.t
+++ b/t/mailer-base.t
@@ -1,0 +1,71 @@
+use strict;
+use warnings;
+
+use Cwd;
+use File::Copy;
+use File::Spec;
+use File::Temp qw/ tempdir /;
+
+use Test::More;
+
+use_ok( 'Test::Smoke::Mailer::Base' );
+
+my $cwd = cwd();
+my $dummy_copy_dir = File::Spec->catdir($cwd, 't', 'logs', 'rtc-126010');
+ok(-d $dummy_copy_dir, "Located directory for dummy copy");
+my $rpt = 'mktest.rpt';
+my $rpt_file = File::Spec->catfile($dummy_copy_dir, $rpt);
+ok(-f $rpt_file, "rpt file located for testing");
+
+my $tdir = tempdir(CLEANUP => 1);
+
+copy $rpt_file => $tdir or die;
+
+{
+    my %mailer_args = (
+        bcc             => '',
+        cc              => '',
+        ccp5p_onfail    => 0,
+        ddir            => $tdir,
+        from            => '',
+        rptfile         => $rpt,
+        to              => 'daily-build-reports@perl.org',
+        sendmailbin     => 'sendmail',
+        v               => 0,
+    );
+    my $mailer = Test::Smoke::Mailer::Base->new(%mailer_args);
+    isa_ok($mailer, 'Test::Smoke::Mailer::Base');
+
+    my $string = $mailer->fetch_report();
+    like($string, qr/^Smoke/, "Got expected response from fetch_report");
+}
+
+{
+    my $bad_report = "$$-nonexistent-report.txt";
+    my %mailer_args = (
+        bcc             => '',
+        cc              => '',
+        ccp5p_onfail    => 0,
+        ddir            => $tdir,
+        from            => '',
+        rptfile         => $bad_report,
+        to              => 'daily-build-reports@perl.org',
+        sendmailbin     => 'sendmail',
+        v               => 0,
+    );
+    my $mailer = Test::Smoke::Mailer::Base->new(%mailer_args);
+    isa_ok($mailer, 'Test::Smoke::Mailer::Base');
+
+    local $@;
+    my $bad_report_path = File::Spec->catfile($tdir, $bad_report);
+    ok(! -f $bad_report_path, "File does not exist (as intended)");
+    my $expect = "Cannot read '\Q$bad_report_path\E'";
+    eval { $mailer->fetch_report(); };
+    like($@, qr/^$expect/,
+        "Got expected error message from non-existent report file");
+
+    my $error = $mailer->error();
+    is($error, '', "No error because none set directly in Test::Smoke::Mailer::Base");
+}
+
+done_testing();

--- a/t/mailer.t
+++ b/t/mailer.t
@@ -24,6 +24,7 @@ use_ok( 'Test::Smoke::Mailer' );
 use Test::Smoke::Util 'parse_report_Config';
 
 SKIP: {
+    note("Mail::Sendmail with PASS config");
     my $mhowto = 'Mail::Sendmail';
     local $@;
     my $load_error = do {
@@ -64,6 +65,7 @@ SKIP: {
 }
 
 SKIP: {
+    note("Mail::Sendmail with FAIL config");
     my $mhowto = 'Mail::Sendmail';
     local $@;
     my $load_error = do {
@@ -114,6 +116,7 @@ SKIP: {
 }
 
 SKIP: {
+    note("mail with PASS config");
     my $mhowto = 'mail';
     my $bin = whereis( $mhowto ) or skip "No '$mhowto' found", 5;
     write_report( $eg_config ) or skip "Cannot write report", 5;
@@ -141,6 +144,7 @@ SKIP: {
 }
 
 SKIP: {
+    note("mailx with PASS config");
     my $mhowto = 'mailx';
     my $bin = whereis( $mhowto ) or skip "No '$mhowto' found", 5;
     write_report( $eg_config ) or skip "Cannot write report", 5;
@@ -168,6 +172,7 @@ SKIP: {
 }
 
 SKIP: {
+    note("sendmail with PASS config");
     my $mhowto = 'sendmail';
     $^O eq 'VMS' and skip "Do not try '$mhowto' on $^O", 5;
     local $ENV{PATH} = "$ENV{PATH}:/usr/sbin";


### PR DESCRIPTION
**Note:** This branch is built on top of the code in pull request https://github.com/Perl-Toolchain-Gang/Test-Smoke/pull/54.  In that p.r. we call attention to GH #52 and GH #53.  So this p.r. ideally should be applied after 53 and 54.

This branch addresses the second Note in https://github.com/Perl-Toolchain-Gang/Test-Smoke/pull/54#issue-4502738175 and then adds additional tests to boost statement, branch and subroutine coverage of lib/Test/Smoke/Mailer/Base.pm to 100% (assuming platform has `sendmail`).

Some explanatory notes added to t/mailer.t.